### PR TITLE
Added email authorization page

### DIFF
--- a/Todoist/Todoist/App.xaml.cs
+++ b/Todoist/Todoist/App.xaml.cs
@@ -1,13 +1,28 @@
-﻿using Todoist.Pages;
-
-namespace Todoist;
+﻿namespace Todoist;
 
 public partial class App : Application
 {
-	public App(IDeviceDisplay deviceDisplay)
+    public new static App Current => (App)Application.Current;
+
+    public IServiceProvider Services { get; }
+
+
+    public App()
 	{
+        Services = ConfigureServices();
+
 		InitializeComponent();
 
-		MainPage = new AuthorizationPage(deviceDisplay);
-	}
+		MainPage = new AppShell();
+    }
+
+
+    private static IServiceProvider ConfigureServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(DeviceDisplay.Current);
+
+        return services.BuildServiceProvider();
+    }
 }

--- a/Todoist/Todoist/AppShell.xaml
+++ b/Todoist/Todoist/AppShell.xaml
@@ -5,10 +5,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:Todoist"
     xmlns:pages="clr-namespace:Todoist.Pages"
+    xmlns:constants="clr-namespace:Todoist.Constants"
     Shell.FlyoutBehavior="Disabled">
 
     <ShellContent
         ContentTemplate="{DataTemplate pages:AuthorizationPage}"
-        Route="authorization" />
+        Route="{Static constants:ShellNavigationConstants.MainAuthorizationPage}"/>
+
+    <ShellContent
+        ContentTemplate="{DataTemplate pages:EmailAuthorizationPage}"/>
 
 </Shell>

--- a/Todoist/Todoist/AppShell.xaml.cs
+++ b/Todoist/Todoist/AppShell.xaml.cs
@@ -1,9 +1,14 @@
-﻿namespace Todoist;
+﻿using Todoist.Constants;
+using Todoist.Pages;
+
+namespace Todoist;
 
 public partial class AppShell : Shell
 {
 	public AppShell()
 	{
-		InitializeComponent();
-	}
+        Routing.RegisterRoute(ShellNavigationConstants.EmailAuthorizationPage, typeof(EmailAuthorizationPage));
+
+        InitializeComponent();
+    }
 }

--- a/Todoist/Todoist/Constants/ShellNavigationConstants.cs
+++ b/Todoist/Todoist/Constants/ShellNavigationConstants.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Todoist.Constants
+{
+    public static class ShellNavigationConstants
+    {
+        public static string MainAuthorizationPage => "authorization";
+
+        public static string EmailAuthorizationPage => "authorization/email";
+    }
+}

--- a/Todoist/Todoist/Controls/AuthorizationFormView.cs
+++ b/Todoist/Todoist/Controls/AuthorizationFormView.cs
@@ -1,0 +1,61 @@
+﻿using System.Windows.Input;
+
+namespace Todoist.Controls
+{
+    public class AuthorizationFormView : ContentView
+    {
+        public static readonly BindableProperty EmailProperty =
+            BindableProperty.Create(nameof(Email), typeof(string), typeof(AuthorizationFormView), string.Empty, BindingMode.TwoWay);
+
+        public static readonly BindableProperty PasswordProperty =
+            BindableProperty.Create(nameof(Password), typeof(string), typeof(AuthorizationFormView), string.Empty, BindingMode.TwoWay);
+
+        public static readonly BindableProperty TapCommandProperty =
+            BindableProperty.Create(nameof(TapCommand), typeof(ICommand), typeof(AuthorizationFormView), null);
+
+        public static readonly BindableProperty SubmitCommandProperty =
+            BindableProperty.Create(nameof(SubmitCommand), typeof(ICommand), typeof(AuthorizationFormView), null);
+
+        public static readonly BindableProperty CloseCommandProperty =
+            BindableProperty.Create(nameof(CloseCommand), typeof(ICommand), typeof(AuthorizationFormView), null);
+
+        public static readonly BindableProperty IsSubmittedProperty =
+            BindableProperty.Create(nameof(IsSubmitted), typeof(bool), typeof(AuthorizationFormView), false, BindingMode.TwoWay);
+
+        public string Email
+        {
+            get => (string)GetValue(EmailProperty);
+            set => SetValue(EmailProperty, value);
+        }
+
+        public string Password
+        {
+            get => (string)GetValue(PasswordProperty);
+            set => SetValue(PasswordProperty, value);
+        }
+
+        public ICommand TapCommand
+        {
+            get => (ICommand)GetValue(TapCommandProperty);
+            set => SetValue(TapCommandProperty, value);
+        }
+
+        public ICommand SubmitCommand
+        {
+            get => (ICommand)GetValue(SubmitCommandProperty);
+            set => SetValue(SubmitCommandProperty, value);
+        }
+
+        public ICommand CloseCommand
+        {
+            get => (ICommand)GetValue(CloseCommandProperty);
+            set => SetValue(CloseCommandProperty, value);
+        }
+
+        public bool IsSubmitted
+        {
+            get => (bool)GetValue(IsSubmittedProperty);
+            set => SetValue(IsSubmittedProperty, value);
+        }
+    }
+}

--- a/Todoist/Todoist/Controls/HyperlinkLabel.cs
+++ b/Todoist/Todoist/Controls/HyperlinkLabel.cs
@@ -12,45 +12,45 @@
 
         public Command<string> TapGestureCommand
         {
-            get { return (Command<string>)GetValue(TapGestureCommandProperty); }
+            get => (Command<string>)GetValue(TapGestureCommandProperty);
             set 
             {
                 SetValue(TapGestureCommandProperty, value);
-
-                GestureRecognizers.Clear();
-                GestureRecognizers.Add(new TapGestureRecognizer
-                {
-                    Command = TapGestureCommand,
-                    CommandParameter = Url
-                });
             }
         }
 
         public string Url
         {
-            get { return (string)GetValue(UrlProperty); }
+            get => (string)GetValue(UrlProperty);
             set 
             { 
                 SetValue(UrlProperty, value);
-
-                foreach (var gestureRecognizer in GestureRecognizers)
-                {
-                    if (gestureRecognizer is TapGestureRecognizer tapGestureRecognizer)
-                    {
-                        tapGestureRecognizer.CommandParameter = Url;
-                    }
-                }
             }
         }
 
         public HyperlinkLabel()
         {
             TextDecorations = TextDecorations.Underline;
+
             GestureRecognizers.Add(new TapGestureRecognizer
             {
                 Command = new Command<string>(async (url) => await Launcher.OpenAsync(url)),
-                CommandParameter = string.IsNullOrEmpty(Url) ? DefaultUrl : Url
+                CommandParameter = DefaultUrl
             });
+        }
+
+        protected override void OnBindingContextChanged()
+        {
+            foreach (var gestureRecognizer in GestureRecognizers)
+            {
+                if (gestureRecognizer is TapGestureRecognizer tapGestureRecognizer)
+                {
+                    tapGestureRecognizer.Command = TapGestureCommand ?? tapGestureRecognizer.Command;
+                    tapGestureRecognizer.CommandParameter = string.IsNullOrEmpty(Url) ? DefaultUrl : Url;
+                }
+            }
+
+            base.OnBindingContextChanged();
         }
     }
 }

--- a/Todoist/Todoist/Converters/AllTrueConverter.cs
+++ b/Todoist/Todoist/Converters/AllTrueConverter.cs
@@ -1,0 +1,49 @@
+﻿using System.Globalization;
+
+namespace Todoist.Converters
+{
+    public class AllTrueConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || !targetType.IsAssignableFrom(typeof(bool)))
+            {
+                return false;
+                // Alternatively, return BindableProperty.UnsetValue to use the binding FallbackValue
+            }
+
+            foreach (var value in values)
+            {
+                if (!(value is bool b))
+                {
+                    return false;
+                    // Alternatively, return BindableProperty.UnsetValue to use the binding FallbackValue
+                }
+                else if (!b)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            if (!(value is bool b) || targetTypes.Any(t => !t.IsAssignableFrom(typeof(bool))))
+            {
+                // Return null to indicate conversion back is not possible
+                return null;
+            }
+
+            if (b)
+            {
+                return targetTypes.Select(t => (object)true).ToArray();
+            }
+            else
+            {
+                // Can't convert back from false because of ambiguity
+                return null;
+            }
+        }
+    }
+}

--- a/Todoist/Todoist/Converters/InverterConverter.cs
+++ b/Todoist/Todoist/Converters/InverterConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+
+namespace Todoist.Converters
+{
+    public class InverterConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value is bool b ? !b : BindableProperty.UnsetValue;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value is bool b ? !b : BindableProperty.UnsetValue;
+        }
+    }
+}

--- a/Todoist/Todoist/MauiProgram.cs
+++ b/Todoist/Todoist/MauiProgram.cs
@@ -20,8 +20,6 @@ public static class MauiProgram
         builder.Logging.AddDebug();
         #endif
 
-        builder.Services.AddSingleton(DeviceDisplay.Current);
-
         return builder.Build();
     }
 }

--- a/Todoist/Todoist/Pages/AuthorizationPage.xaml
+++ b/Todoist/Todoist/Pages/AuthorizationPage.xaml
@@ -2,8 +2,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Todoist.Pages.AuthorizationPage"
              xmlns:controls="clr-namespace:Todoist.Controls"
+             xmlns:constants="clr-namespace:Todoist.Constants"
              xmlns:toolkit="clr-namespace:CommunityToolkit.Maui.Behaviors;assembly=CommunityToolkit.Maui">
 
+    <Shell.BackButtonBehavior>
+        <BackButtonBehavior IsVisible="False" IsEnabled="False" />
+    </Shell.BackButtonBehavior>    
+    
     <ContentPage.Behaviors>
         <toolkit:StatusBarBehavior StatusBarColor="{StaticResource Primary}" StatusBarStyle="DarkContent" />
     </ContentPage.Behaviors>
@@ -32,8 +37,9 @@
         <Image Grid.Row="1" Source="motivation_image.png" />
 
         <VerticalStackLayout Grid.Row="2" >
-            <Button Text="Continue with Email" 
-                    Style="{StaticResource EmailAuthorizationButton}" 
+            <Button Text="Continue with Email"
+                    Clicked="OnContinueWithEmailClick"
+                    Style="{StaticResource EmailAuthorizationButtonWithImage}" 
                     Margin="0,0,0,15"/>
             
             <Button Text="Continue with Apple" 
@@ -49,7 +55,9 @@
                        Style="{StaticResource PolicyLabel}"/>
 
                 <controls:HyperlinkLabel x:Name="TermsOfServiceLabel" 
-                                         Text="Terms of Service" 
+                                         Text="Terms of Service"
+                                         Url="{Static constants:RawResourcesConstants.TermsOfServicePage}"
+                                         TapGestureCommand="{Binding HyperlinkLabelTapGestureCommand}"
                                          Style="{StaticResource PolicyLabel}"/>                
             </HorizontalStackLayout>
             
@@ -60,6 +68,8 @@
 
                 <controls:HyperlinkLabel x:Name="PrivacyPolicyLabel" 
                                          Text="Privacy Policy" 
+                                         Url="{Static constants:UrlConstants.PrivacyPolicy}"
+                                         TapGestureCommand="{Binding HyperlinkLabelTapGestureCommand}"
                                          Style="{StaticResource PolicyLabel}"/>
             </HorizontalStackLayout>
         </Grid>

--- a/Todoist/Todoist/Pages/AuthorizationPage.xaml.cs
+++ b/Todoist/Todoist/Pages/AuthorizationPage.xaml.cs
@@ -1,30 +1,27 @@
 using CommunityToolkit.Maui.Views;
-using Todoist.Constants;
+using System.Windows.Input;
 using Todoist.Views;
 
 namespace Todoist.Pages;
 
 public partial class AuthorizationPage : ContentPage
 {
-    private readonly IDeviceDisplay _deviceDisplay;
+    public ICommand HyperlinkLabelTapGestureCommand => new Command<string>(ShowWebViewPopup);
 
-    public AuthorizationPage(IDeviceDisplay deviceDisplay)
+    public AuthorizationPage()
 	{
         BindingContext = this;
         InitializeComponent();
-
-        _deviceDisplay = deviceDisplay;
-
-        TermsOfServiceLabel.Url = RawResourcesConstants.TermsOfServicePage;
-        TermsOfServiceLabel.TapGestureCommand = new Command<string>(ShowWebViewPopup);
-
-        PrivacyPolicyLabel.Url = UrlConstants.PrivacyPolicy;
-        PrivacyPolicyLabel.TapGestureCommand = new Command<string>(ShowWebViewPopup);
     }
 
     private void ShowWebViewPopup(string url)
     {
-        var popup = new WebViewPopup(url, _deviceDisplay);
+        var popup = new WebViewPopup(url);
         this.ShowPopup(popup);
+    }
+
+    private async void OnContinueWithEmailClick(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync("email", true);
     }
 }

--- a/Todoist/Todoist/Pages/EmailAuthorizationPage.xaml
+++ b/Todoist/Todoist/Pages/EmailAuthorizationPage.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Todoist.Pages.EmailAuthorizationPage"
+             xmlns:views="clr-namespace:Todoist.Views"
+             xmlns:controls="clr-namespace:Todoist.Controls"
+             xmlns:toolkit="clr-namespace:CommunityToolkit.Maui.Behaviors;assembly=CommunityToolkit.Maui">
+
+    <ContentPage.Resources>
+        <ResourceDictionary Source="../Resources/Templates/EmailAuthorizationFormTemplate.xaml" />
+    </ContentPage.Resources>
+
+    <Shell.BackButtonBehavior>
+        <BackButtonBehavior IsVisible="False" IsEnabled="False" />
+    </Shell.BackButtonBehavior>
+
+    <ContentPage.Behaviors>
+        <toolkit:StatusBarBehavior StatusBarColor="{StaticResource Primary}" StatusBarStyle="DarkContent" />
+    </ContentPage.Behaviors>
+
+    <controls:AuthorizationFormView Email="{Binding Email}"
+                                    TapCommand="{Binding TapFormCommand}"
+                                    SubmitCommand="{Binding SubmitFormCommand}"
+                                    CloseCommand="{Binding CloseFormCommand}" 
+                                    IsSubmitted="{Binding IsSubmitted}"
+                                    ControlTemplate="{StaticResource EmailAuthorizationFormTemplate}"/>
+</ContentPage>

--- a/Todoist/Todoist/Pages/EmailAuthorizationPage.xaml.cs
+++ b/Todoist/Todoist/Pages/EmailAuthorizationPage.xaml.cs
@@ -1,0 +1,46 @@
+using Todoist.ViewModels;
+
+namespace Todoist.Pages;
+
+public partial class EmailAuthorizationPage : ContentPage
+{
+    private readonly AuthorizationFormViewModel _formViewModel;
+
+    public EmailAuthorizationPage()
+	{
+        _formViewModel = new AuthorizationFormViewModel()
+        {
+            TapFormCommand = new Command(OnFormViewTap),
+            SubmitFormCommand = new Command(OnFormViewSubmit),
+            CloseFormCommand = new Command(OnFormViewClose)
+        };
+
+        // This piece of code and the next on the 25 line is needed due to a strange work of Button enabling with Multibinding:
+        // on a page initializing the result of multibinding is ignoring
+        _formViewModel.IsSubmitted = true;
+
+        BindingContext = _formViewModel;
+        InitializeComponent();
+
+        _formViewModel.IsSubmitted = false;
+    }
+
+    private void OnFormViewTap()
+    {
+#if IOS
+	    Platforms.iOS.Helpers.KeyboardHelper.HideKeyboard();
+#elif ANDROID
+        Platforms.Android.Helpers.KeyboardHelper.HideKeyboard();
+#endif
+    }
+
+    private void OnFormViewSubmit()
+    {
+        _formViewModel.IsSubmitted = !_formViewModel.IsSubmitted;
+    }
+
+    private async void OnFormViewClose()
+    {
+        await Shell.Current.GoToAsync("..", true);
+    }
+}

--- a/Todoist/Todoist/Platforms/Android/Helpers/KeyboardHelper.cs
+++ b/Todoist/Todoist/Platforms/Android/Helpers/KeyboardHelper.cs
@@ -1,0 +1,21 @@
+﻿using Android.Content;
+using Android.Views.InputMethods;
+
+namespace Todoist.Platforms.Android.Helpers
+{
+    public static partial class KeyboardHelper
+    {
+        public static void HideKeyboard()
+        {
+            var context = Platform.AppContext;
+            var inputMethodManager = context.GetSystemService(Context.InputMethodService) as InputMethodManager;
+            if (inputMethodManager != null)
+            {
+                var activity = Platform.CurrentActivity;
+                var token = activity.CurrentFocus?.WindowToken;
+                inputMethodManager.HideSoftInputFromWindow(token, HideSoftInputFlags.None);
+                activity.Window.DecorView.ClearFocus();
+            }
+        }
+    }
+}

--- a/Todoist/Todoist/Platforms/iOS/Helpers/KeyboardHelper.cs
+++ b/Todoist/Todoist/Platforms/iOS/Helpers/KeyboardHelper.cs
@@ -1,0 +1,12 @@
+﻿using UIKit;
+
+namespace Todoist.Platforms.iOS.Helpers
+{
+    public static partial class KeyboardHelper
+    {
+        public static void HideKeyboard()
+        {
+            UIApplication.SharedApplication.Delegate.GetWindow().EndEditing(true);
+        }
+    }
+}

--- a/Todoist/Todoist/Resources/Styles/Colors.xaml
+++ b/Todoist/Todoist/Resources/Styles/Colors.xaml
@@ -8,7 +8,9 @@
     <Color x:Key="White">White</Color>
     <Color x:Key="LightGrey">#6E6E6E</Color>
     <Color x:Key="Black">Black</Color>
+    <Color x:Key="Red">Red</Color>
     <Color x:Key="LightRed">#CA3737</Color>
+    <Color x:Key="Green">Green</Color>
     
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}"/>
     <SolidColorBrush x:Key="WhiteBrush" Color="{StaticResource White}"/>

--- a/Todoist/Todoist/Resources/Styles/Styles.xaml
+++ b/Todoist/Todoist/Resources/Styles/Styles.xaml
@@ -18,6 +18,9 @@
 
     <Style TargetType="Button" x:Key="EmailAuthorizationButton" BasedOn="{StaticResource AuthorizationButton}">
         <Setter Property="BackgroundColor" Value="{StaticResource LightRed}" />
+    </Style>
+
+    <Style TargetType="Button" x:Key="EmailAuthorizationButtonWithImage" BasedOn="{StaticResource EmailAuthorizationButton}">
         <Setter Property="ImageSource" Value="mail_btn_icon.png" />
     </Style>
 
@@ -43,6 +46,20 @@
     <Style TargetType="Label" x:Key="PolicyLabel" BasedOn="{StaticResource DefaultLabel}">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource LightGrey}, Dark={StaticResource White}}" />
         <Setter Property="FontSize" Value="12" />
-    </Style>    
+    </Style>
+
+    <Style TargetType="Label" x:Key="AuthorizationFormHeader" BasedOn="{StaticResource DefaultLabel}">
+        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontAttributes" Value="Bold" />
+    </Style>
+
+    <!-- Entry styles -->
+    <Style x:Key="InvalidEntry" TargetType="Entry">
+        <Setter Property="TextColor" Value="{StaticResource Red}" />
+    </Style>
     
+    <Style x:Key="ValidEntry" TargetType="Entry">
+        <Setter Property="TextColor" Value="{StaticResource Green}" />
+    </Style>
+
 </ResourceDictionary>

--- a/Todoist/Todoist/Resources/Templates/EmailAuthorizationFormTemplate.xaml
+++ b/Todoist/Todoist/Resources/Templates/EmailAuthorizationFormTemplate.xaml
@@ -1,0 +1,115 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:behaviors="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:toolkit="clr-namespace:CommunityToolkit.Maui.Behaviors;assembly=CommunityToolkit.Maui"
+             xmlns:converters="clr-namespace:Todoist.Converters">
+
+    <converters:InverterConverter x:Key="InverterConverter" />
+    <converters:AllTrueConverter x:Key="AllTrueConverter" />
+    
+    <ControlTemplate x:Key="EmailAuthorizationFormTemplate">
+        <Grid RowDefinitions="*,8*,20*"
+              Padding="20, 0, 20, 20" 
+              RowSpacing="10"
+              BackgroundColor="{StaticResource Primary}"
+              IsEnabled="{TemplateBinding IsSubmitted, Converter={StaticResource InverterConverter}}">
+
+            <Grid.GestureRecognizers>
+                <TapGestureRecognizer Command="{TemplateBinding TapCommand}"></TapGestureRecognizer>
+            </Grid.GestureRecognizers>
+
+            <ActivityIndicator Grid.RowSpan="3" 
+                               IsRunning="true" 
+                               IsVisible="{TemplateBinding IsSubmitted}"
+                               ZIndex="1"/>
+
+            <Button Grid.Row="0" 
+                    Text="Close" 
+                    IsEnabled="{TemplateBinding IsSubmitted, Converter={StaticResource InverterConverter}}" 
+                    Command="{TemplateBinding CloseCommand}"  
+                    TextColor="Red"
+                    BackgroundColor="Transparent" 
+                    FontSize="14" 
+                    HorizontalOptions="Start" 
+                    Padding="0">
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal">
+                            <VisualState.Setters>
+                                <Setter Property="Opacity" Value="1" />
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Disabled">
+                            <VisualState.Setters>
+                                <Setter Property="Opacity" Value="0.5" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateManager.VisualStateGroups>
+            </Button>
+
+            <Label Grid.Row="1" 
+                   Text="What's your email address?" 
+                   Style="{StaticResource AuthorizationFormHeader}"/>
+
+            <VerticalStackLayout Grid.Row="2">
+                <Label Text="YOUR EMAIL"
+                       Style="{StaticResource DefaultLabel}"/>
+
+                    <Entry Text="{TemplateBinding Email}"
+                           Placeholder="Email"
+                           Keyboard="Email"
+                           ReturnType="Done"
+                           IsEnabled="{TemplateBinding IsSubmitted, Converter={StaticResource InverterConverter}}"
+                           IsSpellCheckEnabled="false"
+                           Margin="0,5">
+                    
+                        <Entry.Behaviors>
+                            <toolkit:EmailValidationBehavior x:Name="EmailValidator"
+                                                             InvalidStyle="{StaticResource InvalidEntry}"
+                                                             ValidStyle="{StaticResource ValidEntry}"
+                                                             Flags="ValidateOnValueChanged"
+                                                             MinimumLength="5"
+                                                             MaximumLength="255"/>
+                        </Entry.Behaviors>
+                    </Entry>
+
+                <Button Text="Continue with email" 
+                        Style="{StaticResource EmailAuthorizationButton}"
+                        Command="{TemplateBinding SubmitCommand}" >
+                    
+                    <VisualStateManager.VisualStateGroups>
+                        <VisualStateGroup x:Name="CommonStates">
+                            <VisualState x:Name="Normal">
+                                <VisualState.Setters>
+                                    <Setter Property="Opacity" Value="1" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="Disabled">
+                                <VisualState.Setters>
+                                    <Setter Property="Opacity" Value="0.5" />
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateManager.VisualStateGroups>
+                    
+                    <Button.IsEnabled>
+                        <MultiBinding Converter="{StaticResource AllTrueConverter}" 
+                                      FallbackValue="false" 
+                                      TargetNullValue="false">
+                            
+                            <Binding Source="{x:Reference EmailValidator}" 
+                                     Path="IsValid"/>
+                            
+                            <Binding Source="{x:RelativeSource Mode=TemplatedParent}" 
+                                     Path="IsSubmitted" 
+                                     Converter="{StaticResource InverterConverter}"/>
+                        </MultiBinding>
+                    </Button.IsEnabled>
+                </Button>
+            </VerticalStackLayout>
+        </Grid>
+    </ControlTemplate>
+</ResourceDictionary>

--- a/Todoist/Todoist/Todoist.csproj
+++ b/Todoist/Todoist/Todoist.csproj
@@ -56,6 +56,12 @@
 	  <MauiXaml Update="Pages\AuthorizationPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Pages\EmailAuthorizationPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Resources\Templates\EmailAuthorizationFormTemplate.xaml">
+	    <Generator></Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\WebViewPopup.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/Todoist/Todoist/ViewModels/AuthorizationFormViewModel.cs
+++ b/Todoist/Todoist/ViewModels/AuthorizationFormViewModel.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel;
+using System.Windows.Input;
+
+namespace Todoist.ViewModels
+{
+    public class AuthorizationFormViewModel : INotifyPropertyChanged
+    {
+        private bool _isSubmitted;
+
+        public string Email { get; set; }
+
+        public string Password { get; set; }
+
+        public ICommand TapFormCommand { get; set; }
+
+        public ICommand CloseFormCommand { get; set; }
+
+        public ICommand SubmitFormCommand { get; set; }
+
+        public bool IsSubmitted 
+        {
+            get => _isSubmitted;
+            set
+            {
+                _isSubmitted = value;
+                RaisePropertyChanged(nameof(IsSubmitted));
+            }
+        }
+
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public void RaisePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Todoist/Todoist/Views/WebViewPopup.xaml.cs
+++ b/Todoist/Todoist/Views/WebViewPopup.xaml.cs
@@ -1,4 +1,3 @@
-using Android.Content.Res;
 using CommunityToolkit.Maui.Views;
 
 namespace Todoist.Views;
@@ -10,8 +9,10 @@ public partial class WebViewPopup : Popup
 
 	public string UrlOrResourceName { get; set; }
 
-	public WebViewPopup(string urlOrResourceName, IDeviceDisplay deviceDisplay)
+	public WebViewPopup(string urlOrResourceName)
 	{
+        var deviceDisplay = App.Current.Services.GetService<IDeviceDisplay>();
+
         UrlOrResourceName = urlOrResourceName;
         Size = new(
             PopupWidthMultiplier * (deviceDisplay.MainDisplayInfo.Width / deviceDisplay.MainDisplayInfo.Density),


### PR DESCRIPTION
Description:
We need to add email authorization page, which will open on the 'Continue with email' button click

What was done:
- Added some converters: single converter "boolean inverse" and multi converter"are all boleans true"
- Added new control: AuthorizationFormView - which inherits from ContentView
- Added ContentTemplate for added control: this template contains email authorization form
- Added new page, which is using new control and xaml template for it
- Refactored HyperlinkLabel control
- Refactored dependency injection logic

Close button click video demonstration:
https://user-images.githubusercontent.com/123369606/216369224-c711da47-ab63-44f9-93bc-afaa4feef024.mp4

Keyboard hiding on tap video demonstration:
https://user-images.githubusercontent.com/123369606/216369319-b0553a92-8c65-4733-937e-2c24b036bad0.mp4

Email entry validation:
https://user-images.githubusercontent.com/123369606/216369404-a2acac45-6203-40b4-a412-fa477b66b45a.mp4

Continue with email button click:
https://user-images.githubusercontent.com/123369606/216370087-80984381-a0dc-438d-97d7-00540c3c1767.mp4